### PR TITLE
Fix(Progress with Data Switch in Room)

### DIFF
--- a/client/components/Chart/VictoryBarChart.js
+++ b/client/components/Chart/VictoryBarChart.js
@@ -15,12 +15,24 @@ import {download} from '../../utils'
 export default class VictoryBarChart extends Component {
   constructor() {
     super()
+
+  }
+
+  componentDidMount() {
+    this.props.changeStyle(this.props.x, 'x');
+    this.props.changeStyle(this.props.y, 'y');
+    this.props.changeStyle(this.props.color, 'color')
+    this.props.changeStyle(this.props.graphSelected, 'graphSelected')
   }
 
   render() {
     let data = this.props.data
     let downloadPNG = download.bind(this)
-    return (
+
+    if(!Object.keys(this.props.data[0]).includes(this.props.x)) {
+      return "Gathering data..."
+    } else
+      return (
       <div id="container">
         <div id="chart">
           <VictoryChart

--- a/client/components/Chart/VictoryLineGraph.js
+++ b/client/components/Chart/VictoryLineGraph.js
@@ -19,6 +19,13 @@ export default class VictoryLineGraph extends Component {
     this.setState({zoomDomain: domain})
   }
 
+  componentDidMount() {
+    this.props.changeStyle(this.props.x, 'x');
+    this.props.changeStyle(this.props.y, 'y')
+    this.props.changeStyle(this.props.color, 'color')
+    this.props.changeStyle(this.props.graphSelected, 'graphSelected')
+  }
+
   render() {
     const changeStyle = this.props.changeStyle
     let data = this.props.data
@@ -26,7 +33,9 @@ export default class VictoryLineGraph extends Component {
     let y = this.props.y
     let x = this.props.x
     let downloadPNG = download.bind(this)
-
+    if(!Object.keys(this.props.data[0]).includes(this.props.x)) {
+      return "Gathering data..."
+    } else {
     return (
       <div id="container">
         <div id="chart">
@@ -143,4 +152,5 @@ export default class VictoryLineGraph extends Component {
       </div>
     )
   }
+}
 }

--- a/client/components/Chart/VictoryScatterChart.js
+++ b/client/components/Chart/VictoryScatterChart.js
@@ -17,13 +17,23 @@ import {
 } from 'victory'
 
 export default class VictoryScatterChart extends Component {
+
+  componentDidMount() {
+    this.props.changeStyle(this.props.x, 'x');
+    this.props.changeStyle(this.props.y, 'y');
+    this.props.changeStyle(this.props.color, 'color')
+    this.props.changeStyle(this.props.graphSelected, 'graphSelected')
+  }
+
   render() {
     let data = this.props.data
     const changeStyle = this.props.changeStyle
     let y = this.props.y
     let x = this.props.x
     let downloadPNG = download.bind(this)
-
+    if(!Object.keys(this.props.data[0]).includes(this.props.x)) {
+      return "Gathering data..."
+    } else {
     return (
       <div id="container">
         <div id="chart">
@@ -171,5 +181,6 @@ export default class VictoryScatterChart extends Component {
         />
       </div>
     )
+  }
   }
 }

--- a/client/components/EditGraphs/CustomizeMenu.js
+++ b/client/components/EditGraphs/CustomizeMenu.js
@@ -46,7 +46,6 @@ export const CustomizeMenu = function(props) {
           }
         })}
       </select> */}
-
       <SimpleSelect
         items={filterColumn(graphData, 'number')}
         name="Left Axis"

--- a/client/components/EditGraphs/EditView.js
+++ b/client/components/EditGraphs/EditView.js
@@ -61,8 +61,6 @@ class EditView extends React.Component {
     await this.props.gotData()
   }
 
-  triggerRefresh() { }
-
   changeStyle(e, attribute) {
     if (attribute === 'dataId') {
       this.setState({
@@ -121,8 +119,6 @@ class EditView extends React.Component {
 
     console.log('this.props.data', this.props.data)
 
-    const {classes} = this.props
-
     console.log('theeeee state', this.state)
     const { classes } = this.props
 
@@ -174,7 +170,7 @@ class EditView extends React.Component {
         ...this.state,
         downloadPNG: download,
         addComma: addComma,
-        changeSyle: this.changeStyle,
+        changeStyle: this.changeStyle,
         data: data
       }
       if (!data) {
@@ -214,6 +210,8 @@ class EditView extends React.Component {
               {...this.props}
               changeStyle={this.changeStyle}
               graphData={data}
+              owner={matchingUser}
+              user={this.props.user}
             />
           </div>
         </div>
@@ -238,6 +236,7 @@ const mapDispatchToProps = dispatch => ({
 
 const mapStateToProps = state => ({
   data: state.data,
+  user: state.user,
   rooms: state.room.rooms,
   singleRoom: state.room.singleRoom,
   allUsers: state.user.allUsers


### PR DESCRIPTION
These changes seemed to be able to switch between 
-Since the last pull, the second column in saved Dataset 1 (from the seed file) doesn't render (which I think is a good thing, since I think the data for it in our seed file is nonsensical---the nice new column restrictions might just be exposing that.... ha). In order to test switching from the sample data to saved data, just upload another couple sets of data files first. 

-Switching back to the sample data from saved data still doesn't work, but since I'm not certain we want to leave the dummy data in there anyway, I don't know that we should worry about it yet. 